### PR TITLE
fix: Resolve emoji display issues (orange squares)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -28,7 +28,9 @@
       "Bash(pnpm dlx shadcn@latest add:*)",
       "Bash(timeout 10 pnpm dlx shadcn@latest init)",
       "WebFetch(domain:tweakcn.com)",
-      "WebFetch(domain:ui.aceternity.com)"
+      "WebFetch(domain:ui.aceternity.com)",
+      "Bash(git pull:*)",
+      "Bash(git branch:*)"
     ],
     "deny": [],
     "ask": []

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -8,9 +8,16 @@
 /* Amber Minimal Theme Variables */
 :root {
   /* Fonts */
-  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  --font-serif: 'Source Serif 4', Georgia, serif;
-  --font-mono: 'JetBrains Mono', 'Courier New', monospace;
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+               'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+               'Noto Color Emoji', 'EmojiOne Color', 'Android Emoji',
+               'Twemoji Mozilla', sans-serif;
+  --font-serif: 'Source Serif 4', Georgia,
+                'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+                'Noto Color Emoji', serif;
+  --font-mono: 'JetBrains Mono', 'Courier New',
+               'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+               'Noto Color Emoji', monospace;
   
   /* Primary Colors - Light Theme */
   --background: oklch(1.0000 0 0);
@@ -329,6 +336,21 @@ h3 {
   margin-bottom: 1rem;
   font-size: 1.5rem;
   font-weight: 600;
+}
+
+/* Emoji Support Enhancement */
+h1, h2, h3, .page-title, .tab-btn, .nav-btn, .stat-icon, .type-badge {
+  font-variant-emoji: emoji;
+  -webkit-font-feature-settings: "liga" 1, "kern" 1;
+  font-feature-settings: "liga" 1, "kern" 1;
+}
+
+/* Force emoji presentation for critical elements */
+.emoji, [data-emoji], .dashboard-title, .history-title {
+  font-variant-emoji: emoji !important;
+  font-family: 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
+               'Noto Color Emoji', 'EmojiOne Color', 'Android Emoji',
+               'Twemoji Mozilla', var(--font-sans) !important;
 }
 
 /* Forms */

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -133,7 +133,7 @@
     
     <div class="dashboard-container">
         <div class="dashboard-header">
-            <h1>📊 Electricity Tracker Dashboard</h1>
+            <h1 class="dashboard-title">📊 Electricity Tracker Dashboard</h1>
             <p class="dashboard-subtitle">Track your electricity consumption and costs</p>
         </div>
         

--- a/public/history.html
+++ b/public/history.html
@@ -205,7 +205,7 @@
     
     <div class="history-container">
         <div class="history-header">
-            <h1>📋 Transaction History</h1>
+            <h1 class="history-title">📋 Transaction History</h1>
         </div>
         
         <div class="history-tabs">

--- a/public/reading.html
+++ b/public/reading.html
@@ -26,7 +26,7 @@
     
     <div class="page-container">
         <div class="page-header">
-            <h1>📊 New Meter Reading</h1>
+            <h1 class="page-title emoji">📊 New Meter Reading</h1>
             <p class="page-subtitle">Record your current electricity meter reading</p>
         </div>
         


### PR DESCRIPTION
## Summary
- Fix emojis displaying as solid orange squares instead of proper colorful emoji icons
- Add comprehensive emoji font support throughout the application
- Update critical page titles with proper emoji rendering classes

## Changes Made
- **CSS Updates**: Enhanced font stacks with emoji fonts (Apple Color Emoji, Segoe UI Emoji, Noto Color Emoji, etc.)
- **Font Properties**: Added `font-variant-emoji: emoji` for proper emoji presentation
- **HTML Classes**: Added emoji-specific classes to main page titles:
  - Dashboard: "📊 Electricity Tracker Dashboard" 
  - History: "📋 Transaction History"
  - Reading: "📊 New Meter Reading"
- **Cross-browser Support**: Fallback fonts for different operating systems

## Test plan
- [ ] Verify dashboard page shows colourful bar chart emoji (📊) instead of orange square
- [ ] Verify history page shows colourful clipboard emoji (📋) instead of orange square  
- [ ] Test on Chrome, Firefox, Safari, and Edge browsers
- [ ] Verify mobile browser emoji display (iOS Safari, Chrome Mobile)
- [ ] Check emoji rendering across different operating systems (Windows, Mac, Linux)

## Before/After
**Before**: Emojis appeared as solid orange squares  
**After**: Emojis display as proper colourful icons with system emoji fonts