### PR TITLE
fix: CSS ::before pseudo-elements for emoji display (URGENT)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -30,7 +30,8 @@
       "WebFetch(domain:tweakcn.com)",
       "WebFetch(domain:ui.aceternity.com)",
       "Bash(git pull:*)",
-      "Bash(git branch:*)"
+      "Bash(git branch:*)",
+      "Bash(gh pr create:*)"
     ],
     "deny": [],
     "ask": []

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -345,12 +345,42 @@ h1, h2, h3, .page-title, .tab-btn, .nav-btn, .stat-icon, .type-badge {
   font-feature-settings: "liga" 1, "kern" 1;
 }
 
+/* CSS-based emoji injection with proper Unicode rendering */
+.dashboard-title::before {
+  content: "\1F4CA\FE0F";
+  font-family: 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', 'Segoe UI Symbol', 'EmojiOne Color', 'Android Emoji', 'Twemoji Mozilla';
+  font-variant-emoji: emoji;
+  margin-right: 0.5rem;
+  font-size: 1em;
+}
+
+.history-title::before {
+  content: "\1F4CB\FE0F";
+  font-family: 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', 'Segoe UI Symbol', 'EmojiOne Color', 'Android Emoji', 'Twemoji Mozilla';
+  font-variant-emoji: emoji;
+  margin-right: 0.5rem;
+  font-size: 1em;
+}
+
+.reading-title::before {
+  content: "\1F4CA\FE0F";
+  font-family: 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', 'Segoe UI Symbol', 'EmojiOne Color', 'Android Emoji', 'Twemoji Mozilla';
+  font-variant-emoji: emoji;
+  margin-right: 0.5rem;
+  font-size: 1em;
+}
+
+.voucher-title::before {
+  content: "\1F4B3\FE0F";
+  font-family: 'Apple Color Emoji', 'Segoe UI Emoji', 'Noto Color Emoji', 'Segoe UI Symbol', 'EmojiOne Color', 'Android Emoji', 'Twemoji Mozilla';
+  font-variant-emoji: emoji;
+  margin-right: 0.5rem;
+  font-size: 1em;
+}
+
 /* Force emoji presentation for critical elements */
-.emoji, [data-emoji], .dashboard-title, .history-title {
+.emoji, [data-emoji], .dashboard-title, .history-title, .reading-title, .voucher-title {
   font-variant-emoji: emoji !important;
-  font-family: 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
-               'Noto Color Emoji', 'EmojiOne Color', 'Android Emoji',
-               'Twemoji Mozilla', var(--font-sans) !important;
 }
 
 /* Forms */

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -133,7 +133,7 @@
     
     <div class="dashboard-container">
         <div class="dashboard-header">
-            <h1 class="dashboard-title">&#128202;&#65039; Electricity Tracker Dashboard</h1>
+            <h1 class="dashboard-title">Electricity Tracker Dashboard</h1>
             <p class="dashboard-subtitle">Track your electricity consumption and costs</p>
         </div>
         

--- a/public/history.html
+++ b/public/history.html
@@ -205,7 +205,7 @@
     
     <div class="history-container">
         <div class="history-header">
-            <h1 class="history-title">&#128203;&#65039; Transaction History</h1>
+            <h1 class="history-title">Transaction History</h1>
         </div>
         
         <div class="history-tabs">

--- a/public/reading.html
+++ b/public/reading.html
@@ -26,7 +26,7 @@
     
     <div class="page-container">
         <div class="page-header">
-            <h1 class="page-title emoji">&#128202;&#65039; New Meter Reading</h1>
+            <h1 class="reading-title">New Meter Reading</h1>
             <p class="page-subtitle">Record your current electricity meter reading</p>
         </div>
         

--- a/public/voucher.html
+++ b/public/voucher.html
@@ -26,7 +26,7 @@
     
     <div class="page-container">
         <div class="page-header">
-            <h1>&#128179;&#65039; Add Voucher</h1>
+            <h1 class="voucher-title">Add Voucher</h1>
         </div>
         
         <div class="voucher-form-container">


### PR DESCRIPTION
## 🚨 URGENT FIX - HTML Entities Failed Completely

The previous HTML entity approach with Unicode variation selector **completely failed** - emojis are still showing as orange squares in production.

## New Approach: CSS ::before Pseudo-elements

This implements a more robust CSS-based solution that injects emojis through CSS content property:

### Changes Made:
1. **Reverted HTML entities** back to clean text titles
2. **Added CSS ::before pseudo-elements** for each page:
   - Dashboard: `\1F4CA\FE0F` (📊 bar chart + variation selector)
   - History: `\1F4CB\FE0F` (📋 clipboard + variation selector)  
   - Reading: `\1F4CA\FE0F` (📊 bar chart + variation selector)
   - Voucher: `\1F4B3\FE0F` (💳 credit card + variation selector)

3. **Enhanced CSS properties**:
   - Proper emoji font stack in content property
   - `font-variant-emoji: emoji` for explicit rendering
   - `margin-right: 0.5rem` for proper spacing

### Why This Should Work:
- **CSS content injection** bypasses HTML parsing issues
- **Direct Unicode escape sequences** with variation selector
- **Explicit emoji font control** through CSS font-family
- **Cross-browser compatibility** through multiple font fallbacks
