### PR TITLE
Add shareable invitation links and tenant-based family management

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -38,7 +38,8 @@
       "Bash(npm update:*)",
       "WebFetch(domain:resend.com)",
       "WebSearch",
-      "Bash(pgrep:*)"
+      "Bash(pgrep:*)",
+      "Bash(gh pr view:*)"
     ],
     "deny": [],
     "ask": []

--- a/index.js
+++ b/index.js
@@ -1589,10 +1589,10 @@ app.post('/api/invitations/generate-link', authMiddleware, tenantMiddleware, asy
     const emailInvitationId = Math.random().toString(36).substring(2, 15);
     await db.prepare(`
       INSERT INTO email_invitations (
-        id, tenant_id, sender_user_id, recipient_email, invitation_type,
+        id, tenant_id, sent_by_user_id, recipient_email, invitation_type,
         invite_code, email_subject, email_body_html, email_body_text,
-        expires_at, sent_at, status, metadata
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, 'link_generated', ?)
+        expires_at, status, metadata
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'link_generated', ?)
     `).bind(
       emailInvitationId,
       tenant.id,

--- a/index.js
+++ b/index.js
@@ -1596,7 +1596,7 @@ app.post('/api/invitations/generate-link', authMiddleware, tenantMiddleware, asy
       tenant.id,
       user.userId,
       'whatsapp-shareable-link',
-      'link',
+      'new_account',
       inviteCode,
       `Invitation to join ${invitationData.senderName}'s PowerMeter family account`,
       `Generated shareable link: ${inviteUrl}`,

--- a/index.js
+++ b/index.js
@@ -1195,7 +1195,7 @@ app.post('/api/invitations/family', authMiddleware, tenantMiddleware, async (c) 
         tenant_id, sent_by_user_id, invitation_type, recipient_email,
         invite_code, email_subject, email_body_html, email_body_text,
         expires_at
-      ) VALUES (?, ?, 'family', ?, ?, 'temp', 'temp', 'temp', ?)
+      ) VALUES (?, ?, 'referral', ?, ?, 'temp', 'temp', 'temp', ?)
     `).bind(
       tenant.id,
       user.userId,
@@ -1595,8 +1595,8 @@ app.post('/api/invitations/generate-link', authMiddleware, tenantMiddleware, asy
     `).bind(
       tenant.id,
       user.userId,
-      recipientEmail,
-      'family',
+      'whatsapp-shareable-link',
+      'link',
       inviteCode,
       `Invitation to join ${invitationData.senderName}'s PowerMeter family account`,
       `Generated shareable link: ${inviteUrl}`,

--- a/index.js
+++ b/index.js
@@ -1585,16 +1585,14 @@ app.post('/api/invitations/generate-link', authMiddleware, tenantMiddleware, asy
 
     const whatsappUrl = `https://wa.me/?text=${encodeURIComponent(whatsappMessage)}`;
 
-    // Create email invitation record for tracking
-    const emailInvitationId = Math.random().toString(36).substring(2, 15);
+    // Create email invitation record for tracking (let id auto-increment)
     await db.prepare(`
       INSERT INTO email_invitations (
-        id, tenant_id, sent_by_user_id, recipient_email, invitation_type,
+        tenant_id, sent_by_user_id, recipient_email, invitation_type,
         invite_code, email_subject, email_body_html, email_body_text,
         expires_at, status, metadata
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'link_generated', ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'sent', ?)
     `).bind(
-      emailInvitationId,
       tenant.id,
       user.userId,
       recipientEmail,

--- a/public/settings.html
+++ b/public/settings.html
@@ -514,7 +514,9 @@
                                       invitation.status === 'opened' ? '#ffc107' :
                                       invitation.status === 'clicked' ? '#17a2b8' : '#6c757d';
 
-                    const typeLabel = invitation.invitation_type === 'family' ? '👨‍👩‍👧‍👦 Family' : '🌟 Referral';
+                    const typeLabel = invitation.invitation_type === 'family' ? '👨‍👩‍👧‍👦 Family' :
+                                      invitation.invitation_type === 'referral' ? '🌟 New Account' :
+                                      invitation.invitation_type === 'link' ? '📱 WhatsApp Link' : '❓ Unknown';
                     const countLabel = invitation.count > 1 ? ` <span style="color: #666; font-size: 14px;">x${invitation.count}</span>` : '';
 
                     html += `

--- a/public/settings.html
+++ b/public/settings.html
@@ -516,7 +516,8 @@
 
                     const typeLabel = invitation.invitation_type === 'family' ? '👨‍👩‍👧‍👦 Family' :
                                       invitation.invitation_type === 'referral' ? '🌟 New Account' :
-                                      invitation.invitation_type === 'link' ? '📱 WhatsApp Link' : '❓ Unknown';
+                                      (invitation.invitation_type === 'new_account' && invitation.recipient_email === 'whatsapp-shareable-link') ? '📱 WhatsApp Link' :
+                                      invitation.invitation_type === 'new_account' ? '🌟 New Account' : '❓ Unknown';
                     const countLabel = invitation.count > 1 ? ` <span style="color: #666; font-size: 14px;">x${invitation.count}</span>` : '';
 
                     html += `


### PR DESCRIPTION
## Summary
- convert dashboards, transaction history, and voucher/reading CRUD to tenant-scoped queries and add admin-only member removal plus invitation clearing endpoints
- build shareable invitation flow with link/token generation, WhatsApp text, invite landing page, and registration auto-fill to streamline family onboarding
- refresh settings UI to group invites, surface clear-all and removal actions, and improve Resend testing-mode messaging with friendlier sender names
- declare FROM_EMAIL, document RESEND_API_KEY, and tighten email service error handling for clearer feedback in testing environments
